### PR TITLE
Проброс значения поля MODEL.FIELD в событие change

### DIFF
--- a/common.blocks/i-model/__field/i-model__field.js
+++ b/common.blocks/i-model/__field/i-model__field.js
@@ -120,7 +120,8 @@
             this._value = (this.params.preprocess || this._preprocess).call(this, this._raw);
             this._formatted = (this.params.format || this._format).call(this, this._value, this.params.formatOptions || {});
 
-            this._trigger(opts && opts.isInit ? 'init' : 'change', $.extend({ value: this._value }, opts));
+            opts && (opts.value = this._value);
+            this._trigger(opts && opts.isInit ? 'init' : 'change', opts);
             
             return this;
         },


### PR DESCRIPTION
i-glue- филды, связывающие поля модели с контролами, в методе onFieldChange(e, data) ожидают значение поля модели в data.value.
В случае с MODEL.FIELD.rollback, значение не передается
Добавил значение из MODEL.FIELD._value.
