### PR TITLE
Некорректное сравнение полей типа "array"

### DIFF
--- a/common.blocks/i-model/__field/_type/i-model__field_type_array.js
+++ b/common.blocks/i-model/__field/_type/i-model__field_type_array.js
@@ -4,6 +4,15 @@
         _default: [],
 
         /**
+         * Поверяет равно ли текущее значение поля значению переменной value
+         * @param {*} value значение для сравнения с текущим значением
+         * @returns {boolean}
+         */
+        isEqual: function(value) {
+            return value === this.get() || this.isEmpty() && this.checkEmpty(value);
+        },
+
+        /**
          * Возвращает копию исходного массива, чтобы исключить возможность
          * изменения внутреннего свойства
          * @returns {Array}


### PR DESCRIPTION
### Описание проблемы

Функция isEqual в блоке i-model__field.js сравнивает текущее значение поля с зафиксированным значением:

return value === this.get() ...

Проблема возникает в полях типа array. Перед сравнением вызывается функция _preprocess (из model__field_type_array.js). Ей передается массив value, а возвращается копия этого массива.

В итоге, несмотря на равенство массивов по содержимому, при сравнении всегда получается fasle. Это не позволяет корректно проверить наличие изменений функций isChanged.
### Решение

Переопределил функцию isEqual в блоке model__field_type_array.js, чтобы убрать из нее вызов _preprocess. 
