### PR TITLE
Непредвиденное удаление моделей с одинаковыми id, но разными путями

### DIFF
--- a/common.blocks/i-model/i-model.js
+++ b/common.blocks/i-model/i-model.js
@@ -632,6 +632,7 @@
          * @param {String|Object} modelParams имя модели или параметры модели
          * @param {String} modelParams.name имя модели
          * @param {String|Number} [modelParams.id] идентификатор, если не указан, создается автоматически
+         * @param {String} [modelParams.path] путь модели
          * @param {String} [modelParams.parentName] имя родительской модели
          * @param {String|Number} [modelParams.parentId] идентификатор родительской модели
          * @param {String} [modelParams.parentPath] путь родительской модели
@@ -649,7 +650,7 @@
                 models = [],
                 modelsCacheByName = modelsGroupsCache[name],
 
-                path = MODEL.buildPath(modelParams),
+                path = modelParams.path || MODEL.buildPath(modelParams),
                 paths = path.split(MODELS_SEPARATOR);
 
             if (!MODEL.decls[name])


### PR DESCRIPTION
Когда метод `destruct` получает модель, он формирует объект с ее параметрами, включая путь:

<pre>modelParams = {
    path: modelParams.path(),
    name: modelParams.name,
    id: modelParams.id
};</pre>

Этот объект затем попадает в метод `MODEL.get`, который не ожидает готовый путь и пытается сформировать его самостоятельно. Однако в случае с `destruct` для формирования пути не хватает сведений о родительской модели. В результате для удаления отбираются модели с одинаковыми идентификаторами, принадлежащие разным родительским моделям.

Пример. При удалении модели, имеющей путь
`model-rest__creative-parameters:3.model-rest__creative-parameter:STUB`
также удаляются модели с путями
`model-rest__creative-parameters:1.model-rest__creative-parameter:STUB`
`model-rest__creative-parameters:2.model-rest__creative-parameter:STUB`
