### PR TITLE
i-model__field_type_array  bugfix

### DIFF
--- a/common.blocks/i-model/__field/_type/i-model__field_type_array.js
+++ b/common.blocks/i-model/__field/_type/i-model__field_type_array.js
@@ -122,13 +122,24 @@
         },
 
         /**
+         * Форматирует значение поля
+         * @param {*} value
+         * @param {Object} [options]
+         * @returns {String}
+         * @private
+         */
+        _format: function(value, options) {
+            return value;
+        },
+
+        /**
          * Проверяет, что занчение поля равно переданному значению по содержимому
          * @param value
          */
         isEqual: function(value) {
             var val = this._raw;
 
-            return val && Array.isArray(value) && value.length === val.length && value.every(function(item, i) {
+            return val && Array.isArray(value) && value.length === val.length && Array.every(value, function(item, i) {
                 return val[i] === item;
             });
         }

--- a/common.blocks/i-model/__field/_type/i-model__field_type_array.test.js
+++ b/common.blocks/i-model/__field/_type/i-model__field_type_array.test.js
@@ -363,6 +363,16 @@ BEM.TEST.decl('i-model__field_type_array', function() {
             expect(onMap).toHaveBeenCalled();
         });
 
+        it('should be equal', function() {
+            var model = BEM.MODEL.create('array-type-field-special', { f: [1, 2, 3] }),
+                field = model.get('f');
+
+            field[0] = '';
+            model.set('f', field);	
+        
+            expect(model.get('f')).toEqual(model.get('f', 'format'));
+        });
+
     });
 
 });


### PR DESCRIPTION
Если в сеттер поля передать модифицированное значение этого поля то это значение не устанавливалось и происходила рассинхронизация значений _raw и _formatted. 
Проблема была в методе isEqual. В нем вызывался переопределенный  метод every   
