### PR TITLE
Установка корректного fixedValue в зависимые поля

### DIFF
--- a/common.blocks/i-model/i-model.js
+++ b/common.blocks/i-model/i-model.js
@@ -175,7 +175,7 @@
             if (!field || !fieldsScheme) return this;
 
             if (!field.isEqual(value)) {
-                field.set(value, opts);
+                field[opts.isInit ? 'initData' : 'set'](value, opts);
             }
 
             return this;


### PR DESCRIPTION
Сейчас для всех зависимых полей при инициализации fixedValue = undefined
Хочется, чтобы в качестве fixedValue в зависимом поле выставлялось значение, вычисленное от fixedValue-значений его родителей
