### PR TITLE
Opts from set method of model are bubbling to model-list change event

### DIFF
--- a/common.blocks/i-model/__field/_type/i-model__field_type_models-list.js
+++ b/common.blocks/i-model/__field/_type/i-model__field_type_models-list.js
@@ -46,8 +46,13 @@
 
                     model
                         .on('change', function(e, data) {
-                                                              //data field is deprecated, use model instead
-                            field._trigger('change', $.extend({ data: model, model: model }, data));
+                            field._trigger(
+                                'change',
+                                $.extend({
+                                    // @deprecated use model instead
+                                    data: model,
+                                    model: model
+                                }, data));
                         })
                         .on('destruct', function(e, data) {
                             list.remove(data.model.id);

--- a/common.blocks/i-model/__field/_type/i-model__field_type_models-list.test.js
+++ b/common.blocks/i-model/__field/_type/i-model__field_type_models-list.test.js
@@ -71,7 +71,9 @@ BEM.TEST.decl('i-model__field_type_model-list', function() {
         });
 
         it('should fire change event with correct opts', function () {
-            var model, onModelInListChanged, data = null;
+            var model,
+                onModelInListChanged,
+                data;
 
             runs(function() {
                 model = BEM.MODEL.create('model-list-type-field', {


### PR DESCRIPTION
Добавил всплытие объекта `opts` при изменении модели, находящейся в `model-list`. Меня немного смущает, что поле с изменившейся моделью приходит в обработчик с названием `data`.
