### PR TITLE
i-model: Неправильное построение пути к моделе, если id предка - 0.

### DIFF
--- a/common.blocks/i-model/i-model.js
+++ b/common.blocks/i-model/i-model.js
@@ -941,7 +941,7 @@
 
                 parts[el] = model && model.path() ||
                     (typeof path === 'object' ? MODEL.buildPath(path) : path) ||
-                    (name ? name + (!isNaN(parseFloat(id)) && isFinite(id) ? ID_SEPARATOR + id : '') : '');
+                    (name ? name + (typeof id !== 'undefined' ? ID_SEPARATOR + id : '') : '');
             });
 
             return (parts.parent ? parts.parent + CHILD_SEPARATOR : '') +


### PR DESCRIPTION
Возможна ситуация когда модель создающаяся через i-glue имеет неправильный путь, при modelParentId = 0;
