### PR TITLE
i-model: ошибка создания модели без data во время getOrCreate.

### DIFF
--- a/common.blocks/i-model/i-model.js
+++ b/common.blocks/i-model/i-model.js
@@ -703,10 +703,11 @@
          */
         getOrCreate: function(modelParams) {
             if (typeof modelParams === 'string') modelParams = { name: modelParams };
+            var modelData = MODEL.modelsData[modelParams.name];
 
             return MODEL.getOne(modelParams) || MODEL.create(
                 modelParams,
-                MODEL.modelsData[modelParams.name][MODEL.buildPath(modelParams)] || {});
+                modelData && modelData[MODEL.buildPath(modelParams)] || {});
         },
 
         /**


### PR DESCRIPTION
i-model: если в getOrCreate вызывается создание модели, а у нее не указанно поле data, то получаем ошибку.

Для избежания подобного добавил проверку.
