### PR TITLE
Добавлена поддержка id-шников в полях типа model и models-list

### DIFF
--- a/common.blocks/i-model/__field/_type/i-model__field_type_model.js
+++ b/common.blocks/i-model/__field/_type/i-model__field_type_model.js
@@ -7,7 +7,12 @@
          * @returns {MODEL.FIELD.types.model}
          */
         initData: function(data) {
-            this._value = MODEL.create({ name: this.params.modelName, parentModel: this.model }, data);
+            //если в data пришла строка - то это id дочерней модели
+            if (typeof data === 'string') {
+                this._value = MODEL.getOrCreate({ name: this.params.modelName, id: data, parentModel: this.model });
+            } else {
+                this._value = MODEL.create({ name: this.params.modelName, parentModel: this.model }, data);
+            }
 
             this._initEvents();
 

--- a/common.blocks/i-model/__field/_type/i-model__field_type_model.test.js
+++ b/common.blocks/i-model/__field/_type/i-model__field_type_model.test.js
@@ -50,6 +50,18 @@ BEM.TEST.decl('i-model__field_type_model', function() {
             expect(BEM.MODEL.get('inner-model').length).toEqual(0);
         });
 
+        it('submodel with id shoud not create twice', function() {
+            BEM.MODEL.create({ name: 'inner-model', id: 'innerId', parentName: 'model-type-field', parentId: 'id' },
+                { innerF: 'inner1' });
+
+            var model = BEM.MODEL.create({ name: 'model-type-field', id: 'id' }, {
+                    f: 'innerId'
+                });
+
+            expect(model.get('f').get('innerF')).toEqual('inner1');
+            model.destruct();
+        });
+
         it('should set model as value', function() {
             var model = BEM.MODEL.create('model-type-field', {
                     f: {

--- a/common.blocks/i-model/__field/_type/i-model__field_type_models-list.js
+++ b/common.blocks/i-model/__field/_type/i-model__field_type_models-list.js
@@ -56,7 +56,9 @@
                 _createModel: function(data) {
                     var model = data instanceof MODEL ?
                         data :
-                        MODEL.create({ name: field.params.modelName, parentModel: field.model }, data);
+                        typeof data === 'string' ?
+                            MODEL.getOrCreate({ name: field.params.modelName, id: data, parentModel: field.model }) :
+                            MODEL.create({ name: field.params.modelName, parentModel: field.model }, data);
 
                     model
                         .on('change', function(e, data) {

--- a/common.blocks/i-model/__field/_type/i-model__field_type_models-list.test.js
+++ b/common.blocks/i-model/__field/_type/i-model__field_type_models-list.test.js
@@ -30,6 +30,27 @@ BEM.TEST.decl('i-model__field_type_model-list', function() {
             expect(BEM.MODEL.get('list-inner-model').length).toEqual(0);
         });
 
+        it('inner model with id should not create twice', function() {
+            BEM.MODEL.create(
+                {
+                    name: 'list-inner-model',
+                    id: 'innerId',
+                    parentName: 'model-list-type-field',
+                    parentId: 'id'
+                },
+                {
+                    id: 'innerId',
+                    f: 'innerString'
+                });
+            var model = BEM.MODEL.create({ name: 'model-list-type-field', id: 'id' }, {
+                list: ['innerId']
+            });
+
+            expect(model.get('list').getByIndex(0).get('f')).toEqual('innerString');
+
+            model.destruct();
+        });
+
         it('should create models at index', function () {
             var model = BEM.MODEL.create('model-list-type-field', {
                 list: [{ id: 1, f: 'f', n: 3 }]


### PR DESCRIPTION
Если при создании модели для поля model передается в качестве данных строка - обрабатывать ее как id модели
Если при создании модели для поля models-list передается массив со строками - обрабатывать их как массив c  id-шникам для дочерних моделей
