### PR TITLE
Добавил поле `changedFields` в data-объект события `change`

### DIFF
--- a/common.blocks/i-model/i-model.js
+++ b/common.blocks/i-model/i-model.js
@@ -419,7 +419,7 @@
          * @private
          */
         _fireChange: function(opts) {
-            this.trigger('change', opts);
+            this.trigger('change', $.extend({}, opts, { changedFields: this.changed }));
             this.changed = [];
         },
 


### PR DESCRIPTION
В котором перечислены все поля модели, которые менялись.

Проблема: при подписке не `change` всей модели, после вызова `update` и обновления нескольких полей, тригерится `change` только для одного поля и узнать про изменения остальных нельзя.