### PR TITLE
Фикс добавления уничтоженных моделей в models-list

### DIFF
--- a/common.blocks/i-model/__field/_type/i-model__field_type_models-list.js
+++ b/common.blocks/i-model/__field/_type/i-model__field_type_models-list.js
@@ -230,8 +230,15 @@
             });
 
             MODEL.on({ name: field.params.modelName, parentModel: field.model }, 'create', function(e, data) {
+                var model = data.model;
+
                 setTimeout(function() {
-                    if (data.model && list._getIndex(data.model.id) === undefined)
+                    var isModelDestructed = !MODEL.models[model.name][model.path()];
+                    if (isModelDestructed) {
+                        return;
+                    }
+
+                    if (model && list._getIndex(model.id) === undefined)
                         list.add(data.model);
                 }, 0);
             });


### PR DESCRIPTION
Если добавить модель в поле `models-list`, а потом удалить ее оттуда, то она все равно добавлялась в коллекцию на следующем тике.