### PR TITLE
i-model__field_type_models-list .isChanged для только что созданной модели возвращает true

### DIFF
--- a/common.blocks/i-model/__field/_type/i-model__field_type_model.js
+++ b/common.blocks/i-model/__field/_type/i-model__field_type_model.js
@@ -206,6 +206,14 @@
          */
         isEqual: function(val) {
             return this._value.isEqual(val);
+        },
+
+        /**
+         * Возвращает фиксированное значение модели
+         * @returns {Object}
+         */
+        getFixedValue: function() {
+            return this._value.getFixedValue();
         }
     });
 })(BEM.MODEL, jQuery);

--- a/common.blocks/i-model/__field/_type/i-model__field_type_model.test.js
+++ b/common.blocks/i-model/__field/_type/i-model__field_type_model.test.js
@@ -277,6 +277,16 @@ BEM.TEST.decl('i-model__field_type_model', function() {
                 model.destruct();
             });
         });
-    });
 
+        describe('.getFixedValue', function() {
+            it('should be equal to fixed data of self model', function() {
+                var model = BEM.MODEL.create('model-type-field', { f: { innerF: 'str' } }),
+                    fieldModel = model.get('f');
+
+                expect(model.fields.f.getFixedValue()).toEqual(fieldModel.getFixedValue());
+
+                model.destruct();
+            });
+        });
+    });
 });

--- a/common.blocks/i-model/__field/_type/i-model__field_type_models-list.js
+++ b/common.blocks/i-model/__field/_type/i-model__field_type_models-list.js
@@ -244,13 +244,13 @@
          * @returns {MODEL.FIELD}
          */
         fixData: function() {
-            this._fixedValue = this._raw.map(function(model) {
-                return model.toJSON();
-            }, this);
-
             this._raw.forEach(function (model) {
                 model.fix();
             });
+
+            this._fixedValue = this._raw.map(function(model) {
+                return model.getFixedValue();
+            }, this);
 
             return this;
         },

--- a/common.blocks/i-model/__field/_type/i-model__field_type_models-list.test.js
+++ b/common.blocks/i-model/__field/_type/i-model__field_type_models-list.test.js
@@ -327,6 +327,29 @@ BEM.TEST.decl('i-model__field_type_model-list', function() {
                 model.destruct();
             });
 
+            it('should not be changed after create when inner models have internal fields', function() {
+                BEM.MODEL.decl('list-with-internal-field', {
+                    list: {
+                        type: 'models-list',
+                        modelName: 'model-with-internal-field'
+                    }
+                });
+
+                BEM.MODEL.decl('model-with-internal-field', {
+                    modelId: {
+                        type: 'id',
+                        internal: true
+                    },
+                    field: 'string'
+                });
+
+                var model = BEM.MODEL.create('list-with-internal-field', { list: [{ modelId: 1, field: 'f' }] });
+
+                expect(model.isChanged()).toBe(false);
+
+                model.destruct();
+            });
+
             it('should be changed after update', function() {
                 var model = BEM.MODEL.create('model-list-type-field');
 
@@ -423,5 +446,22 @@ BEM.TEST.decl('i-model__field_type_model-list', function() {
                 model2.destruct();
             });
         });
+
+        describe('.getFixedValue', function() {
+            it('should return array with fixed values of each model of list', function() {
+
+                var model = BEM.MODEL.create('model-list-type-field', {
+                    list: [{ id: 1, f: 'f1' }, { id: 2, f: 'f2' }]
+                });
+
+                expect(model.fields.list.getFixedValue())
+                    .toEqual([
+                        model.get('list').getByIndex(0).getFixedValue(),
+                        model.get('list').getByIndex(1).getFixedValue()
+                    ]);
+
+                model.destruct()
+            })
+        })
     });
 });

--- a/common.blocks/i-model/i-model.js
+++ b/common.blocks/i-model/i-model.js
@@ -324,6 +324,20 @@
         },
 
         /**
+         * Возвращает объект с фиксированными значениями полей
+         * @returns {Object}
+         */
+        getFixedValue: function() {
+            var res = {};
+
+            $.each(this.fields, function(fieldName, field) {
+                res[fieldName] = field.getFixedValue();
+            });
+
+            return res;
+        },
+
+        /**
          * Назначает обработчик события на модель или поле модели
          * @param {String} [field] имя поля
          * @param {String} e имя события

--- a/common.blocks/i-model/i-model.test.js
+++ b/common.blocks/i-model/i-model.test.js
@@ -866,4 +866,45 @@ BEM.TEST.decl('i-model', function() {
             model2.destruct();
         });
     });
+
+    describe('.getFixedValue', function() {
+        it('after create should return hash which is equal to hash that have been passed to create method', function() {
+            var initValues = {
+                    f1: 'f1',
+                    f2: 'f2',
+                    f3: 3,
+                    f4: [1, 2, 3],
+                    f5: false,
+                    f6: {
+                        innerF: 'str',
+                        innerModelLev2: { innerFLev2: 'innerFLev2' }
+                    }
+                },
+                model = BEM.MODEL.create('model-for-compare', initValues);
+
+            expect(model.getFixedValue()).toEqual(initValues);
+
+            model.destruct();
+        });
+
+        it('values of fields of returned hash should be equal to fixed values of model fields', function() {
+            var initValues = {
+                    f6: {
+                        innerF: 'str',
+                        innerModelLev2: { innerFLev2: 'innerFLev2' }
+                    }
+                },
+                model = BEM.MODEL.create('model-for-compare', initValues),
+                innerFChangedValue = 'str2',
+                innerFLev2ChangedValue = 'innerFLev2ChangedValue';
+
+            model.get('f6').set('innerF', innerFChangedValue);
+            model.get('f6').get('innerModelLev2').set('innerFLev2', innerFLev2ChangedValue);
+            model.fix();
+
+            expect(model.getFixedValue().f6).toEqual(model.get('f6').getFixedValue());
+
+            model.destruct();
+        });
+    });
 });


### PR DESCRIPTION
Пример:

```javascript
                BEM.MODEL.decl('list-with-internal-field', {
                    list: {
                        type: 'models-list',
                        modelName: 'model-with-internal-field'
                    }
                });

                BEM.MODEL.decl('model-with-internal-field', {
                    modelId: {
                        type: 'id',
                        internal: true  
                    },
                    field: 'string'
                });

                var model = BEM.MODEL.create('list-with-internal-field', { list: [{ modelId: 1, field: 'f' }] });

                model.isChanged() //true
```
Проблема была в том что, ```i-model__field_type_models-list._fixedValue``` хранил в себе массив значениями которого были  результаты метода ```toJSON``` моделей, а ```toJSON``` модели не учитывает поля у которых ```internal: true```. Поменял метод ```i-model__field_type_models-list.fixData```. Сейчас ```i-model__field_type_models-list._fixedValue``` хранит массив 
значениями которого являются результаты метода ```getFixedValue``` моделей из своего списка.