### PR TITLE
При валидации по отдельным полям добавлять имя поля в объект результата

### DIFF
--- a/common.blocks/i-model/i-model.js
+++ b/common.blocks/i-model/i-model.js
@@ -354,7 +354,7 @@
                 e = field;
                 field = undefined;
             }
-            
+
             !field ?
                 this.__base(e, data, fn, ctx) :
                 field.split(' ').forEach(function(name) {
@@ -463,6 +463,11 @@
                 validateRes;
 
             if (name) {
+                // событие validated тригерится даже при валидации отдельных полей
+                // нужно дать понять обработчикам, что происходит валидация конкретного
+                // поля, а не всей модели
+                res.field = name;
+
                 validateRes = this.fields[name].validate();
                 if (validateRes !== true) {
                     res.errorFields = [name];


### PR DESCRIPTION
Суть проблемы в том, что без правок вот этот код включал/выключал кнопку при любой проверке на валидность конкретных полей (в рамках моей задачи проверяется url для подсветки инпута при вводе неверного значения через модельную валидацию 1 поля)

```javascript
this.model.on('validated', function(e, data) {
    this._saveButton.toggleMod('disabled', 'yes', !data.valid);
}, this);
```

Если в результат ответа впихнуть название поля, то жизнь становиться лучше:

```javascript
this.model.on('validated', function(e, data) {
    !data.field && this._saveButton.toggleMod('disabled', 'yes', !data.valid);
}, this);
```