### PR TITLE
add glue-field_type_textarea

### DIFF
--- a/common.blocks/glue-field/_type/glue-field_type_textarea.deps.js
+++ b/common.blocks/glue-field/_type/glue-field_type_textarea.deps.js
@@ -1,0 +1,6 @@
+({
+    mustDeps: [
+        { mods : { type : 'input' } }
+    ],
+    shouldDeps: []
+})

--- a/common.blocks/glue-field/_type/glue-field_type_textarea.js
+++ b/common.blocks/glue-field/_type/glue-field_type_textarea.js
@@ -1,0 +1,16 @@
+modules.define('glue-field', ['i-bem__dom'], function(provide, BEMDOM) {
+
+provide(BEMDOM.decl({ block: 'glue-field_type_textarea', baseBlock: 'glue-field_type_input' }, {
+
+    onSetMod: {
+        js: {
+            inited: function() {
+                this.__base();
+                this.input = this.findBlockOn('textarea');
+            }
+        }
+    },
+}));
+
+});
+

--- a/common.blocks/model/model.js
+++ b/common.blocks/model/model.js
@@ -440,7 +440,7 @@ var MODEL = inherit(events.Emitter, /** @lends MODEL.prototype */ {
      * Проверяет модель на валидность, генерирует событие error с описанием ошибки(ок)
      * @returns {Object}
      */
-    validate: function() {
+    validate: function(name) {
         var _this = this,
             res = {},
             validateRes;


### PR DESCRIPTION
Модификатор для провязки модели с блоком `textarea`. Работает на основе
`glue-field_type_input`.
Issue #176 
